### PR TITLE
Add unique identifiers to records

### DIFF
--- a/resources.json
+++ b/resources.json
@@ -2,33 +2,40 @@
     "acnh": {
         "fish_nh": {
             "endpoint": "Fish_(New_Horizons)",
-            "table_xpath": "//div[@title='Northern Hemisphere']/table[@class='roundy']/tr/td/table"
+            "table_xpath": "//div[@title='Northern Hemisphere']/table[@class='roundy']/tr/td/table",
+            "uid_offset": 100
         },
         "bugs_nh": {
             "endpoint": "Bugs_(New_Horizons)",
-            "table_xpath": "//div[@title='Northern Hemisphere']/table[@class='roundy']/tr/td/table"
+            "table_xpath": "//div[@title='Northern Hemisphere']/table[@class='roundy']/tr/td/table",
+            "uid_offset": 200
         },
         "fish_sh": {
             "endpoint": "Fish_(New_Horizons)",
-            "table_xpath": "//div[@title='Southern Hemisphere']/table[@class='roundy']/tr/td/table"
+            "table_xpath": "//div[@title='Southern Hemisphere']/table[@class='roundy']/tr/td/table",
+            "uid_offset": 100
         },
         "bugs_sh": {
             "endpoint": "Bugs_(New_Horizons)",
-            "table_xpath": "//div[@title='Southern Hemisphere']/table[@class='roundy']/tr/td/table"
+            "table_xpath": "//div[@title='Southern Hemisphere']/table[@class='roundy']/tr/td/table",
+            "uid_offset": 200
         }
     },
     "acnl": {
         "fish": {
             "endpoint": "Fish_(New_Leaf)",
-            "table_xpath": "//div[@id='mw-content-text']/table[@class='roundy'][2]/tr/td/table"
+            "table_xpath": "//div[@id='mw-content-text']/table[@class='roundy'][2]/tr/td/table",
+            "uid_offset": 300
         },
         "bugs": {
             "endpoint": "Bugs_(New_Leaf)",
-            "table_xpath": "//div[@id='mw-content-text']/table[@class='roundy'][2]/tr/td/table"
+            "table_xpath": "//div[@id='mw-content-text']/table[@class='roundy'][2]/tr/td/table",
+            "uid_offset": 400
         },
         "underwater": {
             "endpoint": "Deep-sea_creatures",
-            "table_xpath": "//div[@id='mw-content-text']/table[@class='roundy'][2]/tr/td/table"
+            "table_xpath": "//div[@id='mw-content-text']/table[@class='roundy'][2]/tr/td/table",
+            "uid_offset": 500
         }
     }
 }

--- a/scraper.py
+++ b/scraper.py
@@ -8,6 +8,7 @@ from pathlib import Path
 BASE_URL = "https://animalcrossing.fandom.com/wiki/"
 MONTHS = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"]
 AVAILABILITY_TAG = "availability"
+UID_TAG = "id"
 
 
 def get_resources():
@@ -48,6 +49,8 @@ def build_tree(resource, image_path):
     parsed = etree.HTML(requests.get(BASE_URL + resource['endpoint']).text)
     rows = get_rows(get_table(parsed, resource['table_xpath']))
     record_list = etree.Element("RecordList")
+    uid_offset = resource['uid_offset']
+    uid = 1
 
     headers = [col.text.strip().lower() for col in next(rows).iterchildren(tag='th')]
     for row in rows:
@@ -56,6 +59,13 @@ def build_tree(resource, image_path):
         # column is encountered
         availability = etree.Element(AVAILABILITY_TAG)
         availability.text = '0' * 12
+
+        # Update record id
+        el = etree.Element(UID_TAG)
+        el.text = f'{uid_offset + uid}'
+        uid += 1
+        record.append(el)
+
         for header, col in zip(headers, row):
             if header in MONTHS:
                 text = get_col_text(col)


### PR DESCRIPTION
To be able to uniquely identify a collectible, a unique identifier is
added to the record by the `<id>` tag. With this, we can for example use
Android's shared preferences (which is just a dictionary) to store which collectibles we have captured/donated by using {id: state} pairs.

An offset has been given to each collectible type and an id is given by
counting from 1 when parsing the data. The assumption that there are no
collections with over 100 elements has been made.