### PR TITLE
Use lowercase and underscores for image filenames

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -28,7 +28,7 @@ def get_rows(table):
 
 def save_image(img, image_path):
     url = img.get('src')
-    name = img.get('data-image-key')
+    name = img.get('data-image-key').replace('-', '_').lower()
     r = requests.get(url, stream=True)
     if r.status_code == 200:
         with image_path.joinpath(name).open('wb') as f:


### PR DESCRIPTION
Android can only use image resource ids that have lowercase a-z, 0-9 and
underscores, but the images from the wiki have upperscore letters and
hyphens. With this commit, the filenames are converted to lowercase and
hyphens are substituted by underscores.